### PR TITLE
Fix build issues for sed and libF77

### DIFF
--- a/v7/usr/src/cmd/sed/makefile
+++ b/v7/usr/src/cmd/sed/makefile
@@ -1,4 +1,4 @@
-CFLAGS = -O
+CFLAGS = -O -fcommon
 
 all:	sed
 	:

--- a/v7/usr/src/libF77/abort_.c
+++ b/v7/usr/src/libF77/abort_.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 abort_()
 {

--- a/v7/usr/src/libF77/main.c
+++ b/v7/usr/src/libF77/main.c
@@ -2,16 +2,20 @@
 
 #include <stdio.h>
 #include <signal.h>
+#include <stdlib.h>
 
 int xargc;
 char **xargv;
+
+static void sigfdie();
+static void sigidie();
+static void sigdie(char *s);
 
 main(argc, argv, arge)
 int argc;
 char **argv;
 char **arge;
 {
-int sigfdie(), sigidie();
 
 xargc = argc;
 xargv = argv;

--- a/v7/usr/src/libF77/s_paus.c
+++ b/v7/usr/src/libF77/s_paus.c
@@ -1,13 +1,16 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
 #define PAUSESIG 15
 
+static void waitpause(int);
 
 s_paus(s, n)
 char *s;
 long int n;
 {
 int i;
-int waitpause();
 
 fprintf(stderr, "PAUSE ");
 if(n > 0)
@@ -38,7 +41,9 @@ fprintf(stderr, "Execution resumes after PAUSE.\n");
 
 
 
-static waitpause()
+static void
+waitpause(int sig)
 {
-return;
+    (void)sig; /* unused parameter */
+    return;
 }

--- a/v7/usr/src/libF77/s_rnge.c
+++ b/v7/usr/src/libF77/s_rnge.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 /* called when a subscript is out of range */
 

--- a/v7/usr/src/libF77/s_stop.c
+++ b/v7/usr/src/libF77/s_stop.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 s_stop(s, n)
 char *s;

--- a/v7/usr/src/libF77/signal_.c
+++ b/v7/usr/src/libF77/signal_.c
@@ -1,3 +1,5 @@
+#include <signal.h>
+
 signal_(sigp, procp)
 int *sigp, (**procp)();
 {


### PR DESCRIPTION
## Summary
- fix sed build failure on GCC by enabling `-fcommon`
- add prototypes and missing headers to libF77
- tidy pause handler in libF77

## Testing
- `make -C usr/src/cmd/sed`
- `make -C usr/src/libF77`