### PR TITLE
Add concurrency tests for spinlock and IPC tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+tests/spinlock_threads
+tests/spinlock_processes
+tests/ipc_trace_concurrent

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+CC ?= gcc
+CFLAGS ?= -O2 -Wall
+
+SPINLOCK_HDR = v7/usr/sys/h
+
+TESTS = tests/spinlock_threads tests/spinlock_processes tests/ipc_trace_concurrent
+
+all: $(TESTS)
+
+$(TESTS): tests/%: tests/%.c
+	$(CC) $(CFLAGS) -I$(SPINLOCK_HDR) $< -o $@ -pthread
+
+check: $(TESTS)
+	@set -e; for t in $(TESTS); do echo "Running $$t"; ./$$t; done
+
+clean:
+	rm -f $(TESTS)

--- a/tests/ipc_trace_concurrent.c
+++ b/tests/ipc_trace_concurrent.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <sys/ptrace.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#define PROCS 5
+
+int main(void) {
+    for (int i = 0; i < PROCS; ++i) {
+        pid_t pid = fork();
+        if (pid < 0) {
+            perror("fork");
+            return 1;
+        } else if (pid == 0) {
+            if (ptrace(PTRACE_TRACEME, 0, NULL, NULL) == -1) {
+                perror("ptrace");
+                _exit(1);
+            }
+            _exit(0);
+        }
+    }
+
+    int status;
+    for (int i = 0; i < PROCS; ++i)
+        wait(&status);
+
+    printf("ipc_trace_concurrent OK\n");
+    return 0;
+}

--- a/tests/spinlock_processes.c
+++ b/tests/spinlock_processes.c
@@ -1,0 +1,50 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include "../v7/usr/sys/h/spinlock.h"
+
+#define PROCS 4
+#define ITERS 50000
+
+int main(void) {
+    size_t sz = sizeof(spinlock_t) + sizeof(int);
+    void *shm = mmap(NULL, sz, PROT_READ | PROT_WRITE,
+                     MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shm == MAP_FAILED) {
+        perror("mmap");
+        return 1;
+    }
+
+    spinlock_t *lock = (spinlock_t *)shm;
+    int *counter = (int *)((char*)shm + sizeof(spinlock_t));
+    *counter = 0;
+    spinlock_init(lock);
+
+    for (int p = 0; p < PROCS; ++p) {
+        pid_t pid = fork();
+        if (pid < 0) {
+            perror("fork");
+            return 1;
+        } else if (pid == 0) {
+            for (int i = 0; i < ITERS; ++i) {
+                spinlock_lock(lock);
+                (*counter)++;
+                spinlock_unlock(lock);
+            }
+            _exit(0);
+        }
+    }
+
+    for (int p = 0; p < PROCS; ++p)
+        wait(NULL);
+
+    int expected = PROCS * ITERS;
+    if (*counter != expected) {
+        fprintf(stderr, "counter mismatch: %d expected %d\n", *counter, expected);
+        return 1;
+    }
+    printf("spinlock_processes OK\n");
+    return 0;
+}

--- a/tests/spinlock_threads.c
+++ b/tests/spinlock_threads.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <pthread.h>
+#include "../v7/usr/sys/h/spinlock.h"
+
+#define THREADS 8
+#define ITERS 100000
+
+static spinlock_t lock;
+static int counter = 0;
+
+void* worker(void* arg) {
+    for (int i = 0; i < ITERS; ++i) {
+        spinlock_lock(&lock);
+        counter++;
+        spinlock_unlock(&lock);
+    }
+    return NULL;
+}
+
+int main(void) {
+    pthread_t thr[THREADS];
+    spinlock_init(&lock);
+
+    for (int i = 0; i < THREADS; ++i)
+        pthread_create(&thr[i], NULL, worker, NULL);
+
+    for (int i = 0; i < THREADS; ++i)
+        pthread_join(thr[i], NULL);
+
+    if (counter != THREADS * ITERS) {
+        fprintf(stderr, "counter mismatch: %d\n", counter);
+        return 1;
+    }
+    printf("spinlock_threads OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add Makefile with `check` target to compile and run tests
- add spinlock stress test using threads
- add spinlock stress test using processes
- add concurrent ptrace (IPC trace) test
- ignore built binaries

## Testing
- `make check`