### PR TITLE
Fix bison parse call and add compile db support

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -e
 sudo apt-get update
-APT_PKGS=(clang clang-tidy cmake make bison flex python3-pip)
+APT_PKGS=(clang clang-tidy cmake make bison flex ccache python3-pip)
 for pkg in "${APT_PKGS[@]}"; do
     if ! sudo apt-get install -y "$pkg"; then
         echo "Warning: failed to install $pkg via apt" >&2
     fi
 done
 
-PIP_PKGS=(pre-commit bison)
+PIP_PKGS=(pre-commit compiledb bison)
 for pkg in "${PIP_PKGS[@]}"; do
     if ! pip3 install --break-system-packages "$pkg"; then
         echo "Warning: failed to install $pkg via pip" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,13 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang bison flex clang-tidy cmake make python3-pip
-          pip3 install pre-commit
+          sudo apt-get install -y clang bison flex clang-tidy cmake make python3-pip ccache
+          pip3 install pre-commit compiledb
       - name: Configure
         run: cmake -B build -DCMAKE_C_COMPILER=clang
       - name: Build
         run: cmake --build build
+      - name: Generate compile database
+        run: compiledb -n cmake --build build
       - name: Lint YAML
         run: pre-commit run --files .github/workflows/ci.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,15 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_C_CLANG_TIDY clang-tidy)
 
+# Export compile_commands.json for tooling
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Use ccache when available for faster builds
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+endif()
+
 include(FindBISON)
 
 add_subdirectory(v7/usr/src/cmd)

--- a/README.md
+++ b/README.md
@@ -50,15 +50,17 @@ dpkg-buildpackage
 
 ## Building with CMake
 
-The new build system uses CMake with clang and bison. To build all available
-components, run:
+The new build system uses CMake with clang and bison.  CMake exports
+`compile_commands.json` so editors can understand the build.  To build all
+available components, run:
 
 ```sh
 cmake -B build -DCMAKE_C_COMPILER=clang
 cmake --build build
 ```
 
-Development dependencies can be installed using the helper script:
+Development dependencies (including `compiledb` and `ccache`) can be installed
+using the helper script:
 
 ```sh
 ./.codex/setup.sh

--- a/v7/usr/src/cmd/lex/lmain.c
+++ b/v7/usr/src/cmd/lex/lmain.c
@@ -64,7 +64,7 @@ main(argc,argv)
 	sname[0] = sp;
 	sp =+ slength("INITIAL") + 1;
 	sname[1] = 0;
-	if(yyparse(0)) exit(1);	/* error return code */
+	if(yyparse()) exit(1);	/* error return code */
 		/* may be disposed of: def, subs, dchar */
 	free1core();
 		/* may be gotten: tmpstat, foll, positions, gotof, nexts, nchar, state, atable, sfall, cpackflg */


### PR DESCRIPTION
## Summary
- use ccache if available and export compile commands
- install compiledb/ccache in environment setup and CI
- note compiledb usage in README
- remove argument from `yyparse` call to work with modern bison

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*