### PR TITLE
Add spinlock debug and SVR4 stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,4 +16,18 @@ endif()
 
 include(FindBISON)
 
+option(SPINLOCK_UNIPROCESSOR "Compile out spinlocks" OFF)
+option(USE_TICKET_LOCK "Use fair ticket locks" OFF)
+option(SPINLOCK_DEBUG "Instrument spinlocks" OFF)
+
+if(SPINLOCK_UNIPROCESSOR)
+    add_compile_definitions(SPINLOCK_UNIPROCESSOR)
+endif()
+if(USE_TICKET_LOCK)
+    add_compile_definitions(USE_TICKET_LOCK)
+endif()
+if(SPINLOCK_DEBUG)
+    add_compile_definitions(SPINLOCK_DEBUG)
+endif()
+
 add_subdirectory(v7/usr/src/cmd)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ The kernel spinlock implementation includes an optional fair ticket
 lock.  Define `USE_TICKET_LOCK` when compiling to enable this variant.
 Ticket locks are recommended on multiprocessor machines where fairness
 is desirable; the default lock is faster but can starve under heavy
-contention.
+contention.  Define `SPINLOCK_UNIPROCESSOR` to compile out locking on
+uniprocessor builds or `SPINLOCK_DEBUG` to instrument lock acquire and
+release with timing.
+
+## SVR4 compatibility
+
+A stub module `svr4_machdep.c` is provided for System V Release 4 support. It will translate SVR4 system calls and prepare binaries for execution when fully implemented.
 
 # Source
 
@@ -58,6 +64,7 @@ available components, run:
 cmake -B build -DCMAKE_C_COMPILER=clang
 cmake --build build
 ```
+Optional spinlock features can be toggled with `SPINLOCK_UNIPROCESSOR`, `USE_TICKET_LOCK` and `SPINLOCK_DEBUG` (e.g. `cmake -B build -DSPINLOCK_DEBUG=ON`).
 
 Development dependencies (including `compiledb` and `ccache`) can be installed
 using the helper script:

--- a/v7/usr/sys/h/spinlock.h
+++ b/v7/usr/sys/h/spinlock.h
@@ -8,8 +8,8 @@
  * used.
  *
  * Define USE_TICKET_LOCK for a fair ticket based lock.
- * Define SPINLOCK_UNIPROCESSOR to compile the locking primitives
- * away on uniprocessor systems.
+ * Define SPINLOCK_UNIPROCESSOR to compile the locking primitives away on uniprocessor systems.
+ * Define SPINLOCK_DEBUG to log lock acquisition and release timing.
  *
  * Typical usage:
  *      spinlock_t lock;
@@ -17,11 +17,19 @@
  *      spinlock_lock(&lock);
  *      ... critical section ...
  *      spinlock_unlock(&lock);
+ *
+ * Lock hierarchy guidelines:
+ *   map_spin -> ilock_spin
+ * Acquire map_spin before ilock_spin to avoid deadlocks.
  */
 #ifndef _SYS_SPINLOCK_H_
 #define _SYS_SPINLOCK_H_
 
 #include <stddef.h>
+#ifdef SPINLOCK_DEBUG
+#include <stdio.h>
+#include <time.h>
+#endif
 
 #ifndef SPINLOCK_DEFAULT_ALIGNMENT
 #define SPINLOCK_DEFAULT_ALIGNMENT 64
@@ -52,37 +60,89 @@ static inline unsigned int spinlock_cacheline_size(void)
 #ifndef USE_TICKET_LOCK
 typedef struct spinlock {
         volatile unsigned int lock;
+#ifdef SPINLOCK_DEBUG
+        const char *owner_file;
+        int owner_line;
+        struct timespec acquired;
+#endif
 } __attribute__((aligned(SPINLOCK_DEFAULT_ALIGNMENT))) spinlock_t;
 
 static inline void spinlock_init(spinlock_t *lk)
 {
         lk->lock = 0;
+#ifdef SPINLOCK_DEBUG
+        lk->owner_file = NULL;
+        lk->owner_line = 0;
+        lk->acquired.tv_sec = 0;
+        lk->acquired.tv_nsec = 0;
+#endif
 }
 
-static inline void spinlock_lock(spinlock_t *lk)
+static inline void spinlock_lock_raw(spinlock_t *lk)
 {
         while (__sync_lock_test_and_set(&lk->lock, 1))
                 while (lk->lock)
                         ;
 }
 
-static inline void spinlock_unlock(spinlock_t *lk)
+static inline void spinlock_unlock_raw(spinlock_t *lk)
 {
         __sync_lock_release(&lk->lock);
 }
+
+#ifdef SPINLOCK_DEBUG
+#define SPINLOCK_WARN_NS 100000000ULL /* 100ms */
+
+static inline void spinlock_lock_debug(spinlock_t *lk, const char *file, int line)
+{
+        spinlock_lock_raw(lk);
+        lk->owner_file = file;
+        lk->owner_line = line;
+        clock_gettime(CLOCK_MONOTONIC, &lk->acquired);
+}
+
+static inline void spinlock_unlock_debug(spinlock_t *lk)
+{
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        unsigned long long held =
+            (unsigned long long)(now.tv_sec - lk->acquired.tv_sec) * 1000000000ULL +
+            (unsigned long long)(now.tv_nsec - lk->acquired.tv_nsec);
+        if (held > SPINLOCK_WARN_NS && lk->owner_file)
+                fprintf(stderr, "spinlock %p held %lluns at %s:%d\n", (void*)lk, held, lk->owner_file, lk->owner_line);
+        spinlock_unlock_raw(lk);
+}
+
+#define spinlock_lock(lk)   spinlock_lock_debug((lk), __FILE__, __LINE__)
+#define spinlock_unlock(lk) spinlock_unlock_debug((lk))
+#else
+#define spinlock_lock(lk)   spinlock_lock_raw((lk))
+#define spinlock_unlock(lk) spinlock_unlock_raw((lk))
+#endif
 #else
 typedef struct ticketlock {
         volatile unsigned int next;
         volatile unsigned int owner;
+#ifdef SPINLOCK_DEBUG
+        const char *owner_file;
+        int owner_line;
+        struct timespec acquired;
+#endif
 } __attribute__((aligned(SPINLOCK_DEFAULT_ALIGNMENT))) ticketlock_t;
 
 static inline void ticketlock_init(ticketlock_t *lk)
 {
         lk->next = 0;
         lk->owner = 0;
+#ifdef SPINLOCK_DEBUG
+        lk->owner_file = NULL;
+        lk->owner_line = 0;
+        lk->acquired.tv_sec = 0;
+        lk->acquired.tv_nsec = 0;
+#endif
 }
 
-static inline void ticketlock_acquire(ticketlock_t *lk)
+static inline void ticketlock_acquire_raw(ticketlock_t *lk)
 {
         unsigned int ticket = __sync_fetch_and_add(&lk->next, 1);
         while (__sync_val_compare_and_swap(&lk->owner, ticket, ticket) != ticket)
@@ -90,10 +150,38 @@ static inline void ticketlock_acquire(ticketlock_t *lk)
                         ;
 }
 
-static inline void ticketlock_release(ticketlock_t *lk)
+static inline void ticketlock_release_raw(ticketlock_t *lk)
 {
         __sync_fetch_and_add(&lk->owner, 1);
 }
+
+#ifdef SPINLOCK_DEBUG
+static inline void ticketlock_acquire_debug(ticketlock_t *lk, const char *file, int line)
+{
+        ticketlock_acquire_raw(lk);
+        lk->owner_file = file;
+        lk->owner_line = line;
+        clock_gettime(CLOCK_MONOTONIC, &lk->acquired);
+}
+
+static inline void ticketlock_release_debug(ticketlock_t *lk)
+{
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        unsigned long long held =
+            (unsigned long long)(now.tv_sec - lk->acquired.tv_sec) * 1000000000ULL +
+            (unsigned long long)(now.tv_nsec - lk->acquired.tv_nsec);
+        if (held > SPINLOCK_WARN_NS && lk->owner_file)
+                fprintf(stderr, "ticketlock %p held %lluns at %s:%d\n", (void*)lk, held, lk->owner_file, lk->owner_line);
+        ticketlock_release_raw(lk);
+}
+
+#define ticketlock_acquire(lk) ticketlock_acquire_debug((lk), __FILE__, __LINE__)
+#define ticketlock_release(lk) ticketlock_release_debug((lk))
+#else
+#define ticketlock_acquire(lk) ticketlock_acquire_raw((lk))
+#define ticketlock_release(lk) ticketlock_release_raw((lk))
+#endif
 
 typedef ticketlock_t spinlock_t;
 #define spinlock_init(lk)   ticketlock_init(lk)

--- a/v7/usr/sys/sys/svr4_machdep.c
+++ b/v7/usr/sys/sys/svr4_machdep.c
@@ -1,0 +1,22 @@
+#include "../h/param.h"
+#include "../h/user.h"
+#include "../h/proc.h"
+
+/*
+ * SVR4 compatibility layer.
+ * This module provides hooks for translating SVR4 system calls
+ * and adjusting binary execution formats.  The real implementation
+ * will map SVR4 syscall numbers to native ones and set up the
+ * required process state.
+ */
+
+int svr4_translate_syscall(int sysnum)
+{
+    /* Placeholder translation logic */
+    return sysnum;
+}
+
+void svr4_setup_binary_format(void)
+{
+    /* Placeholder for SVR4 a.out/ELF handling */
+}


### PR DESCRIPTION
## Summary
- instrument spinlock implementation with optional debugging
- expose spinlock configuration flags via CMake
- document build flags and SVR4 compatibility
- introduce stub `svr4_machdep.c` module

## Testing
- `make check`
- `CFLAGS='-DSPINLOCK_DEBUG -O2 -Wall' make check`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: `pre-commit: command not found`)*