### PR TITLE
Add kernel build with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,3 +31,4 @@ if(SPINLOCK_DEBUG)
 endif()
 
 add_subdirectory(v7/usr/src/cmd)
+add_subdirectory(kernel)

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ dpkg-buildpackage
 ## Building with CMake
 
 The new build system uses CMake with clang and bison.  CMake exports
-`compile_commands.json` so editors can understand the build.  To build all
-available components, run:
+`compile_commands.json` so editors can understand the build.  The build
+now includes a small target that compiles the historical kernel sources.
+To build all available components, run:
 
 ```sh
 cmake -B build -DCMAKE_C_COMPILER=clang

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,0 +1,6 @@
+file(GLOB SYS_SRC "${CMAKE_SOURCE_DIR}/v7/usr/sys/sys/*.c")
+file(GLOB DEV_SRC "${CMAKE_SOURCE_DIR}/v7/usr/sys/dev/*.c")
+set(KERNEL_SOURCES ${SYS_SRC} ${DEV_SRC} ${CMAKE_SOURCE_DIR}/v7/usr/sys/conf/c.c)
+add_executable(kernel ${KERNEL_SOURCES})
+target_include_directories(kernel PRIVATE ${CMAKE_SOURCE_DIR}/v7/usr/sys/h)
+target_compile_options(kernel PRIVATE -std=gnu90 -Wno-return-type -Wno-deprecated-non-prototype -fno-builtin -fno-builtin-malloc)


### PR DESCRIPTION
## Summary
- build kernel from historical sources using CMake
- integrate kernel build with top-level CMake
- mention kernel build target in README

## Testing
- `make -s check`
- `pre-commit run --files README.md CMakeLists.txt kernel/CMakeLists.txt` *(fails: `pre-commit: command not found`)*