### PR TITLE
Remove hardcoded clang compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.16)
 project(v7unix C)
 
 set(CMAKE_C_STANDARD 99)
-set(CMAKE_C_COMPILER clang)
 set(CMAKE_C_CLANG_TIDY clang-tidy)
 
 # Export compile_commands.json for tooling


### PR DESCRIPTION
## Summary
- stop forcing clang as `CMAKE_C_COMPILER`

## Testing
- `pre-commit` *(fails: command not found)*