### PR TITLE
Configure CI tools

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -8,9 +8,18 @@ for pkg in "${APT_PKGS[@]}"; do
     fi
 done
 
-PIP_PKGS=(pre-commit compiledb bison)
+PIP_PKGS=(pre-commit compiledb configuredb bison)
 for pkg in "${PIP_PKGS[@]}"; do
     if ! pip3 install --break-system-packages "$pkg"; then
         echo "Warning: failed to install $pkg via pip" >&2
     fi
 done
+
+# Configure tools after installation
+if command -v pre-commit >/dev/null 2>&1; then
+    pre-commit install
+fi
+
+if command -v configuredb >/dev/null 2>&1; then
+    configuredb
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang bison flex clang-tidy cmake make python3-pip ccache
-          pip3 install pre-commit compiledb
+          pip3 install pre-commit compiledb configuredb
+          pre-commit install
+          configuredb
       - name: Configure
         run: cmake -B build -DCMAKE_C_COMPILER=clang
       - name: Build

--- a/README.md
+++ b/README.md
@@ -67,9 +67,14 @@ cmake --build build
 ```
 Optional spinlock features can be toggled with `SPINLOCK_UNIPROCESSOR`, `USE_TICKET_LOCK` and `SPINLOCK_DEBUG` (e.g. `cmake -B build -DSPINLOCK_DEBUG=ON`).
 
-Development dependencies (including `compiledb` and `ccache`) can be installed
-using the helper script:
+Development dependencies (including `pre-commit`, `compiledb`, `configuredb`
+and `ccache`) can be installed using the helper script:
 
 ```sh
 ./.codex/setup.sh
+```
+After running the script, Git hooks can be enabled with:
+
+```sh
+pre-commit install
 ```


### PR DESCRIPTION
## Summary
- install `configuredb` via pip alongside other dev tools
- configure pre-commit hooks automatically
- update documentation for new dependencies

## Testing
- `make check`
- ❌ `pre-commit run --files .github/workflows/ci.yml .codex/setup.sh README.md` *(failed: command not found)*