### PR TITLE
Implement process mailboxes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,3 +31,4 @@ endif()
 
 add_subdirectory(v7/usr/src/cmd)
 add_subdirectory(kernel)
+add_subdirectory(src-user)

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,6 +1,11 @@
 file(GLOB SYS_SRC "${CMAKE_SOURCE_DIR}/v7/usr/sys/sys/*.c")
 file(GLOB DEV_SRC "${CMAKE_SOURCE_DIR}/v7/usr/sys/dev/*.c")
-set(KERNEL_SOURCES ${SYS_SRC} ${DEV_SRC} ${CMAKE_SOURCE_DIR}/v7/usr/sys/conf/c.c)
+set(KERNEL_SOURCES ${SYS_SRC} ${DEV_SRC}
+    ${CMAKE_SOURCE_DIR}/v7/usr/sys/conf/c.c
+    ${CMAKE_SOURCE_DIR}/src-kernel/exo_mailbox.c
+    ${CMAKE_SOURCE_DIR}/src-kernel/exo_ipc_queue.c)
 add_executable(kernel ${KERNEL_SOURCES})
-target_include_directories(kernel PRIVATE ${CMAKE_SOURCE_DIR}/v7/usr/sys/h)
+target_include_directories(kernel PRIVATE
+    ${CMAKE_SOURCE_DIR}/v7/usr/sys/h
+    ${CMAKE_SOURCE_DIR}/src-kernel)
 target_compile_options(kernel PRIVATE -std=gnu90 -Wno-return-type -Wno-deprecated-non-prototype -fno-builtin -fno-builtin-malloc)

--- a/src-kernel/exo_ipc_queue.c
+++ b/src-kernel/exo_ipc_queue.c
@@ -1,0 +1,35 @@
+#include "exo_mailbox.h"
+#include "../v7/usr/sys/h/proc.h"
+#include "../v7/usr/sys/40/param.h"
+
+mailbox_t proc_mailboxes[NPROC];
+
+void exo_ipc_init(void)
+{
+    for (int i = 0; i < NPROC; ++i)
+        mailbox_init(&proc_mailboxes[i]);
+}
+
+mailbox_t *exo_get_mailbox(struct proc *p)
+{
+    int idx = p - proc;
+    if (idx < 0 || idx >= NPROC)
+        return NULL;
+    return &proc_mailboxes[idx];
+}
+
+int exo_ipc_send(struct proc *target, int value)
+{
+    mailbox_t *mb = exo_get_mailbox(target);
+    if (!mb)
+        return -1;
+    return mailbox_send(mb, value);
+}
+
+int exo_ipc_recv(struct proc *p, int *value)
+{
+    mailbox_t *mb = exo_get_mailbox(p);
+    if (!mb)
+        return -1;
+    return mailbox_recv(mb, value);
+}

--- a/src-kernel/exo_mailbox.c
+++ b/src-kernel/exo_mailbox.c
@@ -1,0 +1,37 @@
+#include "exo_mailbox.h"
+
+void mailbox_init(mailbox_t *mb)
+{
+    spinlock_init(&mb->lock);
+    mb->head = 0;
+    mb->tail = 0;
+    mb->count = 0;
+}
+
+int mailbox_send(mailbox_t *mb, int value)
+{
+    int ret = -1;
+    spinlock_lock(&mb->lock);
+    if (mb->count < MAILBOX_SIZE) {
+        mb->buffer[mb->tail] = value;
+        mb->tail = (mb->tail + 1) % MAILBOX_SIZE;
+        mb->count++;
+        ret = 0;
+    }
+    spinlock_unlock(&mb->lock);
+    return ret;
+}
+
+int mailbox_recv(mailbox_t *mb, int *value)
+{
+    int ret = -1;
+    spinlock_lock(&mb->lock);
+    if (mb->count > 0) {
+        *value = mb->buffer[mb->head];
+        mb->head = (mb->head + 1) % MAILBOX_SIZE;
+        mb->count--;
+        ret = 0;
+    }
+    spinlock_unlock(&mb->lock);
+    return ret;
+}

--- a/src-kernel/exo_mailbox.h
+++ b/src-kernel/exo_mailbox.h
@@ -1,0 +1,22 @@
+#ifndef EXO_MAILBOX_H
+#define EXO_MAILBOX_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "../v7/usr/sys/h/spinlock.h"
+
+#define MAILBOX_SIZE 16
+
+typedef struct mailbox {
+    spinlock_t lock;
+    size_t head;
+    size_t tail;
+    size_t count;
+    int buffer[MAILBOX_SIZE];
+} mailbox_t;
+
+void mailbox_init(mailbox_t *mb);
+int mailbox_send(mailbox_t *mb, int value);
+int mailbox_recv(mailbox_t *mb, int *value);
+
+#endif /* EXO_MAILBOX_H */

--- a/src-user/CMakeLists.txt
+++ b/src-user/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB LIB_SRC "${CMAKE_CURRENT_SOURCE_DIR}/lib/*.c")
+add_library(exo_user STATIC ${LIB_SRC})
+target_include_directories(exo_user PUBLIC ${CMAKE_SOURCE_DIR}/src-kernel)
+target_include_directories(exo_user PUBLIC ${CMAKE_SOURCE_DIR}/v7/usr/sys/h)

--- a/src-user/lib/ipc.c
+++ b/src-user/lib/ipc.c
@@ -1,0 +1,19 @@
+#include <unistd.h>
+#include "../../src-kernel/exo_mailbox.h"
+#include "../../v7/usr/sys/40/param.h"
+
+extern mailbox_t proc_mailboxes[NPROC];
+
+int exo_send(int pid, int value)
+{
+    if (pid < 0 || pid >= NPROC)
+        return -1;
+    return mailbox_send(&proc_mailboxes[pid], value);
+}
+
+int exo_recv(int pid, int *value)
+{
+    if (pid < 0 || pid >= NPROC)
+        return -1;
+    return mailbox_recv(&proc_mailboxes[pid], value);
+}

--- a/v7/usr/sys/conf/c.c
+++ b/v7/usr/sys/conf/c.c
@@ -10,6 +10,7 @@
 #include "../h/file.h"
 #include "../h/inode.h"
 #include "../h/acct.h"
+#include "../../../src-kernel/exo_mailbox.h"
 
 int	nulldev();
 int	nodev();
@@ -82,5 +83,6 @@ int	(*ldmpx)() = mpxchan;
 struct	proc	proc[NPROC];
 struct	text	text[NTEXT];
 struct	buf	bfreelist;
+mailbox_t proc_mailboxes[NPROC];
 struct	acct	acctbuf;
 struct	inode	*acctp;

--- a/v7/usr/sys/h/proc.h
+++ b/v7/usr/sys/h/proc.h
@@ -6,6 +6,7 @@
  * Other per process data (user.h)
  * is swapped with the process.
  */
+#include "../../../src-kernel/exo_mailbox.h"
 struct	proc {
 	char	p_stat;
 	char	p_flag;
@@ -23,6 +24,7 @@ struct	proc {
 	caddr_t p_wchan;	/* event process is awaiting */
 	struct text *p_textp;	/* pointer to text structure */
 	struct proc *p_link;	/* linked list of running processes */
+        mailbox_t *p_mailbox;
 	int	p_clktim;	/* time to alarm clock signal */
 };
 

--- a/v7/usr/sys/sys/main.c
+++ b/v7/usr/sys/sys/main.c
@@ -41,6 +41,8 @@ main()
 	proc[0].p_flag |= SLOAD|SSYS;
 	proc[0].p_nice = NZERO;
 	u.u_procp = &proc[0];
+        proc[0].p_mailbox = &proc_mailboxes[0];
+        mailbox_init(proc[0].p_mailbox);
 	u.u_cmask = CMASK;
 
 	/*

--- a/v7/usr/sys/sys/slp.c
+++ b/v7/usr/sys/sys/slp.c
@@ -9,6 +9,7 @@
 #include "../h/inode.h"
 #include "../h/buf.h"
 
+#include "../../../src-kernel/exo_mailbox.h"
 #define SQSIZE 0100	/* Must be power of 2 */
 #define HASH(x)	(( (int) x >> 5) & (SQSIZE-1))
 struct proc *slpque[SQSIZE];
@@ -470,6 +471,8 @@ retry:
 	rpp->p_time = 0;
 	rpp->p_cpu = 0;
 
+        rpp->p_mailbox = &proc_mailboxes[rpp - proc];
+        mailbox_init(rpp->p_mailbox);
 	/*
 	 * make duplicate entries
 	 * where needed


### PR DESCRIPTION
## Summary
- add a simple `mailbox_t` data structure with send/receive helpers
- create per-process mailboxes and assign them during process creation
- expose mailbox-based IPC via the new user library
- update build scripts to compile the new modules

## Testing
- `make`
- `make check`
