### PR TITLE
Prefer clang build and extended tooling

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -3,13 +3,14 @@ set -e
 sudo apt-get update
 # Core development tools
 APT_PKGS=(
-    build-essential clang clang-tidy clang-format lld
-    cmake ninja-build make
+    build-essential clang clang-tidy clang-format clang-tools clangd
+    lld llvm llvm-dev libclang-dev libllvm-dev bolt
+    cmake ninja-build make bear
     bison flex
     gdb lldb valgrind lcov
-    ccache
+    ccache afl++
     python3-pip python3-venv
-    git
+    git jq
     nodejs npm
     coq coq-theories coq-doc
 )
@@ -24,7 +25,7 @@ done
 PIP_PKGS=(
     pre-commit compiledb
     pylint mypy flake8
-    pytest
+    pytest pytest-cov hypothesis lit yamllint
 )
 for pkg in "${PIP_PKGS[@]}"; do
     if ! pip3 install --break-system-packages "$pkg"; then
@@ -44,8 +45,8 @@ done
 cat <<'EOF' >> "$HOME/.codex_env"
 export CC=clang
 export CXX=clang++
-export CFLAGS="-O3 -march=native -fuse-ld=lld"
+export CFLAGS="-O3 -march=native -flto -fuse-ld=lld"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-fuse-ld=lld"
+export LDFLAGS="-fuse-ld=lld -flto"
 EOF
 echo "Add 'source \$HOME/.codex_env' to your shell profile to enable default flags"


### PR DESCRIPTION
## Summary
- default to clang with ccache in `Makefile`
- add a `tidy` target for running clang‑tidy
- expand `.codex/setup.sh` with additional development packages
- enable link-time optimisation flags in default env

## Testing
- `make check`
- `pre-commit run --files Makefile .codex/setup.sh` *(fails: command not found)*